### PR TITLE
sample colors from uploaded images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@ input::-webkit-inner-spin-button {
 }
 
 input[type=number] {
-    width: 3em;
+    width: 2em;
     margin: 8px 0;
     box-sizing: border-box;
     border: none;

--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
     <button id="download">Download</button>
     <span id="colors"></span>
     <button id="add-color">Add Color</button>
+    <input id="upload-image" type="file" accept="image/png, image/jpeg">
+    <label>Sample Colors:</label>
+    <input type="number" id="n-colors">
   </div class="form">
 
   <div id="svg-container"></div>
@@ -23,6 +26,7 @@
   <script src="./js/helper.js"></script>
   <script src="./js/generate.js"></script>
   <script src="./js/color-input.js"></script>
+  <script src="./js/image.js"></script>
   <script src="./js/main.js"></script>
 </body>
 </html>

--- a/js/image.js
+++ b/js/image.js
@@ -1,0 +1,148 @@
+/**
+ * Find `n` distinct colors in image using k-means clustering
+ */
+async function sampleColorsFromImage(file, n) {
+    const image = await getImageData(file);
+    const pixels = lloyds(image, n);
+    return pixels.map(pixelToColor);
+}
+
+function componentToHex(c) {
+    const hex = Math.floor(c).toString(16);
+    return hex.length == 1 ? "0" + hex : hex;
+}
+  
+function rgbToHex(r, g, b) {
+    return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+}
+
+function pixelToColor(pixel) {
+    return rgbToHex(...pixel);
+}
+
+function getImageData(file) {
+    return new Promise((resolve, reject) => {
+        const image = new Image();
+        image.src = URL.createObjectURL(file);
+        image.onload = function() {
+            const canvas = document.createElement('canvas');
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(image, 0, 0);
+            const data = ctx.getImageData(0, 0, canvas.width, canvas.height)
+            resolve(data);
+        };
+        image.onerror = reject;
+    });
+}
+
+function lloyds(image, n) {
+    const threshold = n * 6;
+    let centroids = Array(n).fill(0).map(() => randomPixel());
+    let change = Infinity;
+    const groups = centroids.map((centroid, index) => ({
+        index,
+        centroid,
+        pixels: [],
+    }));
+
+    const pixels = [];
+    for (let y = 0; y < image.height; y++) {
+        for (let x = 0; x < image.width; x++) {
+            pixels.push(get(image, x, y));
+        }
+    }
+
+    while (change > threshold) {
+        // assign pixels to the nearest centroid
+        for (const pixel of pixels) {
+            const g = closestTo(pixel, centroids);
+            groups[g].pixels.push(pixel);
+        }
+
+        // pick new centroids for each group
+        let oldCentroids = centroids;
+        centroids = [];
+        for (const group of groups) {
+            group.centroid = average(group.pixels);
+            centroids.push(group.centroid);
+            group.pixels = []; // clear the groups for the next iteration
+        }
+        
+        // compute change
+        change = 0;
+        for (let i = 0; i < oldCentroids.length; i++) {
+            change += distance(centroids[i], oldCentroids[i]);
+        }
+    }
+
+    return centroids;
+}
+
+function randInt(low, high) {
+    return Math.floor(Math.random() * (high - low)) + low;
+}
+
+function randomPixel() {
+    return [
+        randInt(0, 255),
+        randInt(0, 255),
+        randInt(0, 255),
+    ];
+}
+
+/** get pixel data at column x and row y */
+function get(image, x, y) {
+    const index = y * image.width * 4 + x * 4;
+    return [
+        image.data[index + 0], // r
+        image.data[index + 1], // g
+        image.data[index + 2], // b
+    ];
+}
+
+function closestTo(p, centroids)  {
+    let closest = [-1, Infinity];
+    for (let i = 0; i < centroids.length; i++) {
+        const d = distance(p, centroids[i]);
+        if (d < closest[1]) {
+            closest = [i, d]
+        }
+    }
+    return closest[0];
+}
+
+/**
+ * L1 distance bewteen two pixels
+ */
+function distance(c1, c2) {
+    return 0 +
+        Math.abs(c1[0] - c2[0]) +
+        Math.abs(c1[1] - c2[1]) +
+        Math.abs(c1[2] - c2[2]);
+}
+
+/**
+ * Find the centroid of a group of pixels
+ */
+function average(pixels) {
+    let r = 0;
+    let g = 0;
+    let b = 0;
+    const size = pixels.length;
+
+    if (size === 0) {
+        return randomPixel();
+    }
+
+    for (const p of pixels) {
+        r += p[0];
+        g += p[1];
+        b += p[2];
+    }
+
+    return [
+        r / size,
+        g / size,
+        b / size,
+    ];
+}

--- a/js/main.js
+++ b/js/main.js
@@ -5,15 +5,18 @@ window.addEventListener('load', () => {
     '#002b36', '#073642', '#586e75', '#657b83',
     '#839496', '#93a1a1', '#eee8d5', '#fdf6e3'
   ];
+  const DEFAULT_N_COLORS = 10;
 
   const $contain = document.querySelector('#svg-container');
   const $width = document.querySelector('#width');
   const $height = document.querySelector('#height');
   const $colors = document.querySelector('#colors');
+  const $nColors = document.querySelector('#n-colors');
 
   $width.value = DEFAULT_WIDTH;
   $height.value = DEFAULT_HEIGHT;
   DEFAULT_COLORS.forEach(addColor);
+  $nColors.value = DEFAULT_N_COLORS;
 
   let svg;
 
@@ -21,6 +24,7 @@ window.addEventListener('load', () => {
   document.querySelector('#randomize').addEventListener('click', randomize);
   document.querySelector('#download').addEventListener('click', download);
   document.querySelector('#add-color').addEventListener('click', addNewColor);
+  document.querySelector('#upload-image').addEventListener('change', useColorsFromImage);
   return;
 
   function compute() {
@@ -55,7 +59,28 @@ window.addEventListener('load', () => {
   function getColors() {
     return [].map.call(
       document.querySelectorAll('.color'),
-      (c) => c.value
+      (c) => c.value,
     );
+  }
+
+  function clearColors() {
+    return [].forEach.call(
+      document.querySelectorAll('.color'),
+      (c) => c.parentElement.removeChild(c),
+    );
+  }
+
+  async function useColorsFromImage() {
+    const file = this.files[0];
+    if (file == null) {
+      return;
+    }
+
+    const n = parseInt($nColors.value);
+    const colors = await sampleColorsFromImage(file, n);
+    clearColors();
+    for (const color of colors) {
+      addColor(color);
+    }
   }
 });


### PR DESCRIPTION
- adjust the number input width
- add image upload
- use lloyds to sample n colors from image

Edge case:
- The random centroids for lloyds lead to extremely long runtimes when given color palette images