### PR TITLE
Add buttons for common dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,12 @@
         <label>x</label>
         <input class='text' type="number" id="height">
         <input type="number" id="size" class='hidden'>
+        <button class="dimWidthByHeight">2x2</button>
+        <button class="dimWidthByHeight">3x3</button>
+        <button class="dimWidthByHeight">9x16</button>
+        <button class="dimWidthByHeight">10x16</button>
+        <button class="dimWidthByHeight">16x9</button>
+        <button class="dimWidthByHeight">16x10</button>
         <button id="use-screen">Fit to Screen</button>
       </span>
       <span id='submenu-colors'>

--- a/index.html
+++ b/index.html
@@ -25,9 +25,9 @@
         <button id='pattern-palette' value='palette'>Palette</button>
       </span>
       <span id='submenu-dimensions'>
-        <input class='text' type="number" id="height">
-        <label>x</label>
         <input class='text' type="number" id="width">
+        <label>x</label>
+        <input class='text' type="number" id="height">
         <input type="number" id="size" class='hidden'>
         <button id="use-screen">Fit to Screen</button>
       </span>

--- a/js/main.js
+++ b/js/main.js
@@ -97,6 +97,13 @@ window.addEventListener('load', () => {
   $('#upload-image').addEventListener('change', useColorsFromImage);
   $('#upload-image-button').addEventListener('click', openUploadImage);
   $('#use-screen').addEventListener('click', useScreenDimensions);
+  for (const button of $$('.dimWidthByHeight')) {
+    const [width, height] = button.innerText.trim().split('x')
+    button.addEventListener('click', (e) => {
+      $width.value = width
+      $height.value = height
+    })
+  }
   $('#main-menu-full-screen').addEventListener('click', requestFullScreen);
   return;
 


### PR DESCRIPTION
- Change dimensions inputs to `width` by `height`
  - Screen dimensions are more commonly referred to as `width` x `height`. Change to match.
- Add buttons to quickly select common dimensions (e.g. 2x2, 9x16)